### PR TITLE
Fixed bug on parsing coordinates of WFs when there is no space

### DIFF
--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -211,16 +211,22 @@ def raw_wout_parser(wann_out_file):
                 wf_out_i['spread'] = float(line.split(')')[1].strip())
                 #wf_out_i['spread'] = float(line.split()[-1])
                 try:
-                    x = float(line.split('(')[1].split(')')[0].split(',')[0].strip())
+                    x = float(
+                        line.split('(')[1].split(')')[0].split(',')[0].strip()
+                    )
                 except (ValueError, IndexError):
                     # To avoid that the crasher completely fails, we set None as a fallback
                     x = None
                 try:
-                    y = float(line.split('(')[1].split(')')[0].split(',')[1].strip())
+                    y = float(
+                        line.split('(')[1].split(')')[0].split(',')[1].strip()
+                    )
                 except (ValueError, IndexError):
                     y = None
                 try:
-                    z = float(line.split('(')[1].split(')')[0].split(',')[2].strip())
+                    z = float(
+                        line.split('(')[1].split(')')[0].split(',')[2].strip()
+                    )
                 except (ValueError, IndexError):
                     z = None
                 coord = (x, y, z)

--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -208,14 +208,21 @@ def raw_wout_parser(wann_out_file):
                 wf_out_i['wannier_function'] = int(
                     line.split('(')[0].split()[-1]
                 )
-                wf_out_i['spread'] = float(line.split('(')[1].split()[-1])
+                wf_out_i['spread'] = float(line.split(')')[1].strip())
                 #wf_out_i['spread'] = float(line.split()[-1])
-                #x = float(line.split()[-5].strip(','))
-                #y = float(line.split()[-4].strip(','))
-                #z = float(line.split()[-3].strip(','))
-                x = float(line.split('(')[1].split()[0].strip(','))
-                y = float(line.split('(')[1].split()[1].strip(','))
-                z = float(line.split('(')[1].split()[2].strip(','))
+                try:
+                    x = float(line.split('(')[1].split(')')[0].split(',')[0].strip())
+                except (ValueError, IndexError):
+                    # To avoid that the crasher completely fails, we set None as a fallback
+                    x = None
+                try:
+                    y = float(line.split('(')[1].split(')')[0].split(',')[1].strip())
+                except (ValueError, IndexError):
+                    y = None
+                try:
+                    z = float(line.split('(')[1].split(')')[0].split(',')[2].strip())
+                except (ValueError, IndexError):
+                    z = None
                 coord = (x, y, z)
                 wf_out_i['coordinates'] = coord
                 wf_out.append(wf_out_i)


### PR DESCRIPTION
after the comma (for many-digit numbers). Not perfect,
but good workaround (also for #1) that does not require to change
Wannier90.