### PR TITLE
Remove testing 'config.yml' from repository

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,1 +1,0 @@
-config_example.yml


### PR DESCRIPTION
This should be a machine-specific file, and thus not committed to the repository. There is a 'config_example.yml' that can be adapted on each machine.

The file was already added to ``.gitignore``, but still present in the repo. 