### PR TITLE
Adding a Travis check for bare package import

### DIFF
--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -5,6 +5,9 @@ set -ev
 
 case "$TEST_TYPE" in
     tests)
+        # I make sure that I can import the module without the need of having the AiiDA environment/profile loaded
+        python -c "import aiida_wannier90"
+
         # Run the AiiDA tests
         cd ${TRAVIS_BUILD_DIR}/.travis-data; ./build_wannier90.sh
         python ${TRAVIS_BUILD_DIR}/.travis-data/configure.py ${TRAVIS_BUILD_DIR}/.travis-data ${TRAVIS_BUILD_DIR}/tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,7 @@ env:
   - TEST_TYPE="pre-commit"
   - TEST_TYPE="tests"
 script:
+  # I make sure that I can import the module without the need of having the AiiDA environment/profile loaded
+  - python -c "import aiida_wannier90"
+  # I run all other tests
   - ./.travis-data/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,4 @@ env:
   - TEST_TYPE="pre-commit"
   - TEST_TYPE="tests"
 script:
-  # I make sure that I can import the module without the need of having the AiiDA environment/profile loaded
-  - python -c "import aiida_wannier90"
-  # I run all other tests
   - ./.travis-data/test_script.sh


### PR DESCRIPTION
To ensure that no AiiDA config is needed when only importing the `aiida_wannier90` module.

Fixes #36 - I think with this test we can already close the issue, and the registry will then point to the released version as soon as we release one (at least an alpha)