### PR TITLE
Fix deprecated 'sha' entry in 'python-modernize' pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 # modernizer: make sure our code-base is Python 3 ready
 - repo: https://github.com/python-modernize/python-modernize.git
-  sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
+  rev: "0.7"
   hooks:
   - id: python-modernize
     exclude: ^docs/


### PR DESCRIPTION
Pre-commit changed its configuration format from using a "sha" key to using "rev". Fixed this for python-modernize, using the latest tag.

Since the code is now py3 - compatible, I'm actually not sure we still need ``python-modernize``.