### PR TITLE
Add "python_requires" to setup.json

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -30,6 +30,7 @@
   "install_requires": [
     "aiida-core>=1.0.0,<2"
   ],
+  "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
   "version": "2.0.0a1",
   "keywords": "wannier90 AiiDA workflows plugin",
   "classifiers": [


### PR DESCRIPTION
This will enable automatically installing the right version from pip once we drop py2 support (i.e., py2 will install the older, compatible version).