### PR TITLE
Fix doc build for python3

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -17,8 +17,7 @@
     ],
     "docs": [
       "sphinx",
-      "sphinx-rtd-theme",
-      "aiida-core>=1.1.0,<2"
+      "sphinx-rtd-theme"
     ],
     "dev_precommit": [
       "pre-commit",

--- a/setup.json
+++ b/setup.json
@@ -17,7 +17,8 @@
     ],
     "docs": [
       "sphinx",
-	    "sphinx-rtd-theme"
+      "sphinx-rtd-theme",
+      "aiida-core>=1.1.0,<2"
     ],
     "dev_precommit": [
       "pre-commit",


### PR DESCRIPTION
Fixes #72.

When building with AiiDA v1.1, we now use the `load_documentation_profile` helper provided by AiiDA.

The old code is kept for compatibility with python2 / AiiDA v1.0.