### PR TITLE
Make dependence on ASE explicit

### DIFF
--- a/aiida_wannier90/utils.py
+++ b/aiida_wannier90/utils.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
 import numbers
+
 import six
+import ase
 
 
 def plot_centres_xsf(structure, w90_calc, filename='./wannier.xsf'):
     """
     Plots Wannier function centres in .xsf format
     """
-    ##TODO: remove this disbale when issue #67 is solved
-    import ase  #pylint: disable=import-error
     a = structure.get_ase()
     new_a = a.copy()
     out = w90_calc.out.output_parameters.get_dict()['wannier_functions_output']

--- a/setup.json
+++ b/setup.json
@@ -21,8 +21,8 @@
     ],
     "dev_precommit": [
       "pre-commit",
-	"yapf==0.28",
-	"prospector==1.1.7"
+      "yapf==0.28",
+      "prospector==1.1.7"
     ]
   },
   "name": "aiida-wannier90",
@@ -30,7 +30,8 @@
   "author": "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi & The AiiDA Team.",
   "author_email": "developers@aiida.net",
   "install_requires": [
-    "aiida-core>=1.0.0,<2"
+    "aiida-core>=1.0.0,<2",
+    "ase"
   ],
   "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
   "version": "2.0.0a1",

--- a/setup.json
+++ b/setup.json
@@ -31,7 +31,8 @@
   "author_email": "developers@aiida.net",
   "install_requires": [
     "aiida-core>=1.0.0,<2",
-    "ase"
+    "ase==3.15; python_version<'3.5'",
+    "ase; python_version>='3.5'"
   ],
   "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
   "version": "2.0.0a1",


### PR DESCRIPTION
Fixes #71 

Instead of removing the dependence on ASE, this makes it explicit in `install_requires`.