### PR TITLE
Add missing __all__ in various files

### DIFF
--- a/aiida_wannier90/__init__.py
+++ b/aiida_wannier90/__init__.py
@@ -6,21 +6,24 @@ AiiDA Wannier90 plugin
 This is a plugin for running `Wannier90 <http://wannier.org>`_ calculations on the `AiiDA <http://aiida.net>`_ platform.
 
 Please cite:
-    * *An updated version of wannier90: A tool for obtaining maximally-localised Wannier functions* A. A. Mostofi, J. R. Yates, 
+    * *An updated version of wannier90: A tool for obtaining maximally-localised Wannier functions* A. A. Mostofi, J. R. Yates,
        G. Pizzi, Y. S. Lee, I. Souza, D. Vanderbilt, and N. Marzari *Comput. Phys. Commun.* **185**, 2309 (2014) `
        [Online Journal] <https://doi.org/10.1016/j.cpc.2014.05.003>`_
     * *AiiDA: automated interactive infrastructure and database for computational science* G. Pizzi, A. Cepellotti, R. Sabatini,
-       N. Marzari, and B. Kozinsky, *Comp. Mat. Sci.* **111**, 218-230 (2016) ` [Journal link] <https://doi.org/10.1016/j.commatsci.2015.09.013>`_ 
+       N. Marzari, and B. Kozinsky, *Comp. Mat. Sci.* **111**, 218-230 (2016) ` [Journal link] <https://doi.org/10.1016/j.commatsci.2015.09.013>`_
        `[arXiv link] <https://arxiv.org/abs/1504.01163>`_
 """
 
 from __future__ import absolute_import
+
 __authors__ = "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi & The AiiDA Team."
 __license__ = "MIT License, see LICENSE.txt file."
 ## If upgraded, remember to change it also in setup.json (for pip)
 __version__ = "2.0.0a1"
 
-from . import io  # noqa: disable=F401
-from . import parsers  # noqa: disable=F401
-from . import orbitals  # noqa: disable=F401
-from . import calculations  # noqa: disable=F401
+from . import io
+from . import parsers
+from . import orbitals
+from . import calculations
+
+__all__ = ('io', 'parsers', 'orbitals', 'calculations')

--- a/aiida_wannier90/calculations.py
+++ b/aiida_wannier90/calculations.py
@@ -14,6 +14,8 @@ from aiida.orm import (
 
 from .io import write_win
 
+__all__ = ('Wannier90Calculation', )
+
 
 class Wannier90Calculation(CalcJob):
     """
@@ -152,7 +154,7 @@ class Wannier90Calculation(CalcJob):
         return self.inputs.metadata.options.seedname
 
     def prepare_for_submission(self, folder):  #pylint: disable=too-many-locals, too-many-statements # noqa:  disable=MC0001
-        """ 
+        """
         Routine which creates the input file of Wannier90
         :param folder: a aiida.common.folders.Folder subclass where
             the plugin should put all its files.

--- a/aiida_wannier90/io/__init__.py
+++ b/aiida_wannier90/io/__init__.py
@@ -7,4 +7,6 @@ Writing input files
 This submodule contains helper functions to create input files.
 """
 
-from ._write_win import write_win  # noqa: disable=F401
+from ._write_win import write_win
+
+__all__ = ('write_win', )

--- a/aiida_wannier90/io/_group_list.py
+++ b/aiida_wannier90/io/_group_list.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 from six.moves import zip
 
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+__all__ = ('group_list', 'groups_to_string', 'list_to_grouped_string')
 
 
 def group_list(values):

--- a/aiida_wannier90/io/_write_win.py
+++ b/aiida_wannier90/io/_write_win.py
@@ -12,7 +12,7 @@ from aiida.common import InputValidationError
 from ._group_list import list_to_grouped_string
 import six
 
-__all__ = ['write_win']
+__all__ = ('write_win', )
 
 
 def write_win( # pylint: disable=too-many-arguments
@@ -42,7 +42,7 @@ def write_win( # pylint: disable=too-many-arguments
     :param kpoint_path: List of k-points used for band interpolation.
     :type kpoint_path: aiida.orm.nodes.data.dict.Dict
 
-    :param projections: Orbitals used for the projections. Can be specified either as AiiDA OrbitalData, 
+    :param projections: Orbitals used for the projections. Can be specified either as AiiDA OrbitalData,
      or as a list of strings specifying the projections in Wannier90's format.
     :type projections: aiida.orm.nodes.data.orbital.OrbitalData, aiida.orm.nodes.data.list.List[str]
 

--- a/aiida_wannier90/orbitals.py
+++ b/aiida_wannier90/orbitals.py
@@ -7,7 +7,8 @@ Creating OrbitalData instances
 from __future__ import absolute_import
 import six
 from six.moves import range
-__all__ = ['generate_projections']
+
+__all__ = ('generate_projections', )
 
 
 def _generate_wannier_orbitals( # pylint: disable=too-many-arguments,too-many-locals,too-many-statements # noqa:  disable=MC0001

--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -7,6 +7,12 @@ from six.moves import range
 from aiida.parsers import Parser
 from aiida.common import exceptions as exc
 
+__all__ = (
+    'Wannier90Parser',
+    'band_parser',
+    'raw_wout_parser',
+)
+
 
 class Wannier90Parser(Parser):
     """

--- a/aiida_wannier90/utils.py
+++ b/aiida_wannier90/utils.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 import numbers
 import six
 
+__all__ = ('plot_centres_xsf', 'conv_to_fortran', 'conv_to_fortran_withlists')
+
 
 def plot_centres_xsf(structure, w90_calc, filename='./wannier.xsf'):
     """


### PR DESCRIPTION
Fixes #75.

Some things are currently in the public API, where I'm unsure if they should be:
- in `utils.py`: `plot_centres_xsf`, `conv_to_fortran`, `conv_to_fortran_withlists`
- in `parsers.py`: `band_parser`, `raw_wout_parser`