### PR TITLE
Use aiida calcjob directive in documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/aiida_wannier90/__init__.py
+++ b/aiida_wannier90/__init__.py
@@ -5,13 +5,22 @@ AiiDA Wannier90 plugin
 
 This is a plugin for running `Wannier90 <http://wannier.org>`_ calculations on the `AiiDA <http://aiida.net>`_ platform.
 
-Please cite:
-    * *An updated version of wannier90: A tool for obtaining maximally-localised Wannier functions* A. A. Mostofi, J. R. Yates,
-       G. Pizzi, Y. S. Lee, I. Souza, D. Vanderbilt, and N. Marzari *Comput. Phys. Commun.* **185**, 2309 (2014) `
-       [Online Journal] <https://doi.org/10.1016/j.cpc.2014.05.003>`_
-    * *AiiDA: automated interactive infrastructure and database for computational science* G. Pizzi, A. Cepellotti, R. Sabatini,
-       N. Marzari, and B. Kozinsky, *Comp. Mat. Sci.* **111**, 218-230 (2016) ` [Journal link] <https://doi.org/10.1016/j.commatsci.2015.09.013>`_
-       `[arXiv link] <https://arxiv.org/abs/1504.01163>`_
+**Please cite:**
+
+-  **Wannier90 as a community code: new features and applications**
+   G. Pizzi, V. Vitale, R. Arita, S. Blügel, F. Freimuth, G. Géranton,
+   M. Gibertini, D. Gresch, C. Johnson, T.Koretsune, J. Ibañez-Azpiroz,
+   H. Lee, J. M. Lihm, D. Marchand, A. Marrazzo, Y. Mokrousov,
+   J. I. Mustafa, Y. Nohara, Y. Nomura, L. Paulatto, S. Poncé,
+   T. Ponweiser, J. Qiao, F. Thöle, S. S. Tsirkin, M. Wierzbowska,
+   N. Marzari, D. Vanderbilt, I. Souza, A. A. Mostofi, and J. R. Yates
+   *J. Phys. Cond. Matt.* **32**, 165902 (2020)
+   `[Online Journal] <http://doi.org/10.1088/1361-648X/ab51ff>`_
+-  **AiiDA: automated interactive infrastructure and database for computational science**
+   G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky,
+   *Comp. Mat. Sci.* **111**, 218-230 (2016)
+   `[Journal link] <https://doi.org/10.1016/j.commatsci.2015.09.013>`_
+   `[arXiv link] <https://arxiv.org/abs/1504.01163>`_
 """
 
 from __future__ import absolute_import

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,15 +75,13 @@ except ImportError:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    'sphinx.ext.autodoc', 'sphinx.ext.mathjax', 'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode', 'aiida.sphinxext'
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2.7', None),
-    'aiida': ('http://aiida_core.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3', None),
+    'aiida': ('https://aiida-core.readthedocs.io/en/latest', None),
 }
 
 nitpick_ignore = [('py:obj', 'module')]

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -9,7 +9,8 @@ Reference
 Calculation and Parser classes
 ------------------------------
 
-.. autoclass:: aiida_wannier90.calculations.Wannier90Calculation
+.. aiida-calcjob:: Wannier90Calculation
+    :module: aiida_wannier90.calculations
 
 .. autoclass:: aiida_wannier90.parsers.Wannier90Parser
 

--- a/setup.json
+++ b/setup.json
@@ -17,7 +17,8 @@
     ],
     "docs": [
       "sphinx",
-      "sphinx-rtd-theme"
+      "sphinx-rtd-theme",
+      "sphinxcontrib-details-directive; python_version>='3.0'"
     ],
     "dev_precommit": [
       "pre-commit",


### PR DESCRIPTION
Fixes #22.

* Uses the explicit `aiida-calcjob` directive instead of `automodule` for the `Wannier90Calculation` reference. 
* Adds a `.readthedocs.yml` file for RTD configuration, and fixes missing dependencies for `aiida.sphinxext`.
* Updates the Wannier90 paper link and fixes formatting of the main docstring: The previous version looked fine "accidentally", because bullet lists need to have both a leading and trailing blank line in restructuredtext. Locally, this was broken for me.