### PR TITLE
Remove python2 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,6 @@
 # Install pre-commit hooks via
 # pre-commit install
 
-# modernizer: make sure our code-base is Python 3 ready
-- repo: https://github.com/python-modernize/python-modernize.git
-  rev: "0.7"
-  hooks:
-  - id: python-modernize
-    exclude: ^docs/
-    args:
-      - --write
-      - --nobackups
-
 - repo: local
   hooks:
   - id: yapf

--- a/.travis-data/check_version.py
+++ b/.travis-data/check_version.py
@@ -12,8 +12,6 @@
 Check version number in setup.json and aiida_wannier90/__init__.py and make sure
 they match.
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import json
 import sys

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
 env:
   - INSTALL_TYPE="testing" TEST_TYPE="tests"
   - INSTALL_TYPE="testing_sdist" TEST_TYPE="tests"
 jobs:
   include:
-  - python: "2.7"
-    env: INSTALL_TYPE="dev_precommit" TEST_TYPE="pre-commit"
   - python: "3.7"
     env: INSTALL_TYPE="dev_precommit" TEST_TYPE="pre-commit"
-  - python: "2.7"
-    env: INSTALL_TYPE="docs" TEST_TYPE="docs"
   - python: "3.7"
     env: INSTALL_TYPE="docs" TEST_TYPE="docs"
 cache: pip

--- a/aiida_wannier90/__init__.py
+++ b/aiida_wannier90/__init__.py
@@ -31,8 +31,6 @@ This is a plugin for running `Wannier90 <http://wannier.org>`_ calculations on t
    `[arXiv link] <https://arxiv.org/abs/1504.01163>`_
 """
 
-from __future__ import absolute_import
-
 __authors__ = "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi, Junfeng Qiao, Norma Rivano, and the AiiDA team."
 __license__ = "MIT License, see LICENSE.txt file."
 ## If upgraded, remember to change it also in setup.json (for pip)

--- a/aiida_wannier90/calculations.py
+++ b/aiida_wannier90/calculations.py
@@ -8,7 +8,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 import os
-import six
 import fnmatch
 from collections import namedtuple
 
@@ -144,17 +143,17 @@ class Wannier90Calculation(CalcJob):
 
         spec.input(
             'metadata.options.input_filename',
-            valid_type=six.string_types,
+            valid_type=str,
             default=cls._DEFAULT_INPUT_FILE
         )
         spec.input(
             'metadata.options.output_filename',
-            valid_type=six.string_types,
+            valid_type=str,
             default=cls._DEFAULT_OUTPUT_FILE
         )
         spec.input(
             'metadata.options.parser_name',
-            valid_type=six.string_types,
+            valid_type=str,
             default='wannier90.wannier90'
         )
         # withmpi defaults to "False" in aiida-core 1.0. Below, we override to default to withmpi=True

--- a/aiida_wannier90/calculations.py
+++ b/aiida_wannier90/calculations.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import, print_function, division
 import os
 import six
 import fnmatch

--- a/aiida_wannier90/io/__init__.py
+++ b/aiida_wannier90/io/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 ################################################################################
 # Copyright (c), AiiDA team and individual contributors.                       #

--- a/aiida_wannier90/io/_group_list.py
+++ b/aiida_wannier90/io/_group_list.py
@@ -9,7 +9,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 
-from __future__ import absolute_import
 from six.moves import zip
 
 __all__ = ('group_list', 'groups_to_string', 'list_to_grouped_string')

--- a/aiida_wannier90/io/_group_list.py
+++ b/aiida_wannier90/io/_group_list.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 ################################################################################
 # Copyright (c), AiiDA team and individual contributors.                       #

--- a/aiida_wannier90/io/_group_list.py
+++ b/aiida_wannier90/io/_group_list.py
@@ -9,8 +9,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 
-from six.moves import zip
-
 __all__ = ('group_list', 'groups_to_string', 'list_to_grouped_string')
 
 

--- a/aiida_wannier90/io/_write_win.py
+++ b/aiida_wannier90/io/_write_win.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 ################################################################################
 # Copyright (c), AiiDA team and individual contributors.                       #

--- a/aiida_wannier90/io/_write_win.py
+++ b/aiida_wannier90/io/_write_win.py
@@ -9,9 +9,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 
-from __future__ import unicode_literals
-
-from __future__ import absolute_import
 import copy
 
 from aiida_wannier90.utils import conv_to_fortran_withlists

--- a/aiida_wannier90/io/_write_win.py
+++ b/aiida_wannier90/io/_write_win.py
@@ -15,7 +15,6 @@ from aiida_wannier90.utils import conv_to_fortran_withlists
 from aiida.common import InputValidationError
 
 from ._group_list import list_to_grouped_string
-import six
 
 __all__ = ('write_win', )
 
@@ -289,7 +288,7 @@ def _format_atoms_cart(structure):
         Converts an input list item into a str
         '''
         list_item = copy.deepcopy(list_item)
-        if isinstance(list_item, (str, six.text_type)):
+        if isinstance(list_item, str):
             return list_item
         return ' ' + ' '.join(["{:18.10f}".format(_) for _ in list_item]) + ' '
 

--- a/aiida_wannier90/orbitals.py
+++ b/aiida_wannier90/orbitals.py
@@ -12,8 +12,6 @@
 Creating OrbitalData instances
 ==============================
 """
-import six
-from six.moves import range
 
 __all__ = ('generate_projections', )
 
@@ -119,7 +117,7 @@ def _generate_wannier_orbitals( # pylint: disable=too-many-arguments,too-many-lo
                 'Must supply a StructureData as '
                 'structure if using kind_name'
             )
-        if not isinstance(kind_name, six.string_types):
+        if not isinstance(kind_name, str):
             raise InputValidationError('kind_name must be a string')
 
     if ang_mtm_name is None and ang_mtm_l_list is None:

--- a/aiida_wannier90/orbitals.py
+++ b/aiida_wannier90/orbitals.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 ################################################################################
 # Copyright (c), AiiDA team and individual contributors.                       #

--- a/aiida_wannier90/orbitals.py
+++ b/aiida_wannier90/orbitals.py
@@ -12,7 +12,6 @@
 Creating OrbitalData instances
 ==============================
 """
-from __future__ import absolute_import
 import six
 from six.moves import range
 
@@ -47,7 +46,7 @@ def _generate_wannier_orbitals( # pylint: disable=too-many-arguments,too-many-lo
     :param ang_mtm_name: orbital name or list of orbital names, cannot
                          be used in conjunction with ang_mtm_l_list or
                          ang_mtm_mr_list
-    :param ang_mtm_l_list: angular momentum (either an integer or a list), if 
+    :param ang_mtm_l_list: angular momentum (either an integer or a list), if
                  ang_mtm_mr_list is not specified will return all orbitals associated with it
     :param ang_mtm_mr_list: magnetic angular momentum number must be specified
                        along with ang_mtm_l_list. Note that if this is specified,
@@ -276,14 +275,14 @@ def generate_projections(list_of_projection_dicts, structure):
     :param ang_mtm_name: orbital name or list of orbital names, cannot
         be used in conjunction with ``ang_mtm_l_list`` or ``ang_mtm_mr_list``
         (see ``ang_mtm_l_list`` and ``ang_mtm_mr_list``).
-    :param ang_mtm_l_list: angular momentum (either an integer or a list), if 
+    :param ang_mtm_l_list: angular momentum (either an integer or a list), if
         ``ang_mtm_mr_list`` is not specified will return all orbitals
         associated with it (``angular_momentum``).
     :param ang_mtm_mr_list: magnetic angular momentum number must be specified
         along with ``ang_mtm_l_list`` (``magnetic_number + 1``). Note that
         if this is specified, ``ang_mtm_l_list`` must be an
         integer and not a list.
-    :param spin: the spin, spin up can be specified with ``1``, ``'u'`` or 
+    :param spin: the spin, spin up can be specified with ``1``, ``'u'`` or
         ``'U'`` and spin down can be specified using ``-1``, ``'d'``
         or ``'D'`` (``spin``)
     :param zona: as specified in user guide, applied to all orbitals

--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
 import io
 import os
 import six

--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-import io
 import os
 from aiida.parsers import Parser
 from aiida.common import exceptions as exc
@@ -101,7 +100,7 @@ class Wannier90Parser(Parser):
         if temporary_folder is not None:
             nnkp_temp_path = os.path.join(temporary_folder, nnkp_file_name)
             if os.path.isfile(nnkp_temp_path):
-                with io.open(nnkp_temp_path, 'rb') as handle:
+                with open(nnkp_temp_path, 'rb') as handle:
                     node = SinglefileData(file=handle)
                     self.out('nnkp_file', node)
 

--- a/aiida_wannier90/parsers.py
+++ b/aiida_wannier90/parsers.py
@@ -9,8 +9,6 @@
 ################################################################################
 import io
 import os
-import six
-from six.moves import range
 from aiida.parsers import Parser
 from aiida.common import exceptions as exc
 
@@ -458,7 +456,7 @@ def band_parser_legacy(band_dat, band_kpt, special_points, structure):  # pylint
     appends.sort()
 
     for i, append in enumerate(appends):
-        labels.insert(append[0] + i, (append[2], six.text_type(append[1])))
+        labels.insert(append[0] + i, (append[2], str(append[1])))
     bands = BandsData()
     k = KpointsData()
     k.set_cell_from_structure(structure)

--- a/aiida_wannier90/utils.py
+++ b/aiida_wannier90/utils.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
 import numbers
 
 import six

--- a/aiida_wannier90/utils.py
+++ b/aiida_wannier90/utils.py
@@ -9,8 +9,6 @@
 ################################################################################
 import numbers
 
-import six
-
 __all__ = ('plot_centres_xsf', 'conv_to_fortran', 'conv_to_fortran_withlists')
 
 
@@ -47,7 +45,7 @@ def conv_to_fortran(val, quote_strings=True):
         val_str = "{:d}".format(val)
     elif isinstance(val, numbers.Real):
         val_str = ("{:18.10e}".format(val)).replace('e', 'd')
-    elif isinstance(val, six.string_types):
+    elif isinstance(val, str):
         if quote_strings:
             val_str = "'{!s}'".format(val)
         else:
@@ -83,13 +81,13 @@ def conv_to_fortran_withlists(val, quote_strings=True):
 
         return '.false.'
 
-    if isinstance(val, six.integer_types):
+    if isinstance(val, int):
         return "{:d}".format(val)
 
     if isinstance(val, float):
         return "{:18.10e}".format(val).replace('e', 'd')
 
-    if isinstance(val, six.string_types):
+    if isinstance(val, str):
         if quote_strings:
             return "'{!s}'".format(val)
 

--- a/aiida_wannier90/workflows/minimal.py
+++ b/aiida_wannier90/workflows/minimal.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import, print_function, division
 from aiida import orm
 from aiida.plugins import CalculationFactory
 from aiida.engine import WorkChain, ToContext, calcfunction

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,61 +20,25 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import contextlib
-
 import os
-import sys
 import time
+import contextlib
 
 import aiida_wannier90
 
+# Note: this requires AiiDA v1.1+
+from aiida.manage.configuration import load_documentation_profile
+load_documentation_profile()
+
 # -- General configuration ------------------------------------------------
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:
+# Set the RTD theme only when _not_ on readthedocs. On readthedocs,
+# the READTHEDOCS environment variable is set to 'True'.
+if not os.environ.get('READTHEDOCS', None) == 'True':
     with contextlib.suppress(ImportError):
         import sphinx_rtd_theme  # pylint: disable=import-error
         html_theme = 'sphinx_rtd_theme'
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-try:
-    # For AiiDA v1.1+
-    from aiida.manage.configuration import load_documentation_profile
-    load_documentation_profile()
-except ImportError:
-    # AiiDA versions <1.1
-    # This can be removed when python2 support is dropped, because there
-    # will be no need to build the documentation with AiiDA v1.0.
-    sys.path.append(
-        os.path.join(os.path.split(__file__)[0], os.pardir, os.pardir)
-    )
-    sys.path.append(os.path.join(os.path.split(__file__)[0], os.pardir))
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'rtd_settings'
-
-    if not on_rtd:  # only import and set the theme if we're building docs locally
-        # Load the database environment by first loading the profile and then loading the backend through the manager
-        from aiida.manage.configuration import get_config, load_profile
-        from aiida.manage.manager import get_manager
-        config = get_config()
-        load_profile(config.default_profile_name)
-        get_manager().get_backend()
-    else:
-        from aiida.manage import configuration
-        from aiida.manage.configuration import load_profile, reset_config
-        from aiida.manage.manager import get_manager
-
-        # Set the global variable to trigger shortcut behavior in `aiida.manager.configuration.load_config`
-        configuration.IN_RT_DOC_MODE = True
-
-        # First need to reset the config, because an empty one will have been loaded when `aiida` module got imported
-        reset_config()
-
-        # Load the profile: this will first load the config, which will be the dummy one for RTD purposes
-        load_profile()
-
-        # Finally load the database backend but without checking the schema because there is no actual database
-        get_manager()._load_backend(schema_check=False)  # pylint: disable=protected-access
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'

--- a/examples/example01/create_local_input_folder.py
+++ b/examples/example01/create_local_input_folder.py
@@ -10,7 +10,6 @@
 ################################################################################
 
 import os
-from six.moves import input
 
 from aiida.plugins import DataFactory
 

--- a/examples/example01/create_local_input_folder.py
+++ b/examples/example01/create_local_input_folder.py
@@ -8,8 +8,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
-from __future__ import print_function
 
 import os
 from six.moves import input

--- a/examples/example01/wannier_gaas.py
+++ b/examples/example01/wannier_gaas.py
@@ -8,8 +8,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 
 from aiida.plugins import DataFactory

--- a/examples/workflows/launch_w90_minimal.py
+++ b/examples/workflows/launch_w90_minimal.py
@@ -8,11 +8,10 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
-from __future__ import print_function
+
+import os
 
 import click
-import os
 
 from aiida.engine import run
 from aiida.orm import Str, Dict, Group
@@ -95,7 +94,7 @@ def get_static_inputs():
 
 def get_or_create_pseudo_family():
     """Check if the pseudos are already in the DB, create them otherwise.
-    
+
     Then create (if needed) also a pseudopotential family including it (or pick any already existing)
     and return the name.
     If the family does not exist, it will be created with name 'GaAs-Wannier-example' and a possible prefix.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:frozendict:
+    ignore::DeprecationWarning:pkg_resources:
+    ignore::DeprecationWarning:reentry:
+    ignore::DeprecationWarning:sqlalchemy_utils:

--- a/setup.json
+++ b/setup.json
@@ -21,7 +21,7 @@
     "docs": [
       "sphinx",
       "sphinx-rtd-theme",
-      "sphinxcontrib-details-directive; python_version>='3.0'"
+      "sphinxcontrib-details-directive"
     ],
     "dev_precommit": [
       "pre-commit",
@@ -29,8 +29,7 @@
       "prospector==1.1.7"
     ],
     "atomic_tools": [
-      "ase<=3.15; python_version<'3.5'",
-      "ase; python_version>='3.5'"  
+      "ase"
     ]
   },
   "name": "aiida-wannier90",
@@ -41,7 +40,7 @@
     "aiida-core>=1.0.0,<2"
   ],
   "url": "https://github.com/aiidateam/aiida-wannier90",
-  "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+  "python_requires": ">=3.6",
   "version": "2.0.0",
   "classifiers": [
     "Development Status :: 5 - Production/Stable",
@@ -49,9 +48,10 @@
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Physics",
     "Framework :: AiiDA",
     "Natural Language :: English"

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 
-from __future__ import absolute_import
-import io
 import json
 import os
 
@@ -17,15 +15,20 @@ from setuptools import setup, find_packages
 
 if __name__ == '__main__':
     THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-    with open('setup.json', 'r') as info:
+    with open(
+        os.path.join(THIS_FOLDER, 'setup.json'), 'r', encoding='utf-8'
+    ) as info:
         kwargs = json.load(info)
+
+    with open(
+        os.path.join(THIS_FOLDER, 'README.md'), 'r', encoding='utf-8'
+    ) as readme:
+        long_description = readme.read()
     setup(
         include_package_data=True,
         setup_requires=['reentry'],
         reentry_register=True,
-        long_description=io.open(
-            os.path.join(THIS_FOLDER, 'README.md'), encoding='utf-8'
-        ).read(),
+        long_description=long_description,
         long_description_content_type='text/markdown',
         packages=find_packages(exclude=['aiida']),
         **kwargs

--- a/tests/calculations/test_example.py
+++ b/tests/calculations/test_example.py
@@ -8,7 +8,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 """Test that the example provided in the top-level `examples` folder works."""
-from __future__ import absolute_import
 import os
 import pytest
 import six

--- a/tests/calculations/test_example.py
+++ b/tests/calculations/test_example.py
@@ -10,7 +10,6 @@
 """Test that the example provided in the top-level `examples` folder works."""
 import os
 import pytest
-import six
 
 ENTRY_POINT_NAME = 'wannier90.wannier90'
 
@@ -36,14 +35,10 @@ def prepare_for_submission_from_builder():
 
 
 def load_module(module_name, full_path):
-    if six.PY2:
-        import imp
-        module = imp.load_source(module_name, full_path)
-    else:
-        import importlib.util  # pylint: disable=import-error
-        spec = importlib.util.spec_from_file_location(module_name, full_path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+    import importlib.util  # pylint: disable=import-error
+    spec = importlib.util.spec_from_file_location(module_name, full_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
 
     return module
 

--- a/tests/calculations/test_example.py
+++ b/tests/calculations/test_example.py
@@ -35,7 +35,7 @@ def prepare_for_submission_from_builder():
 
 
 def load_module(module_name, full_path):
-    import importlib.util  # pylint: disable=import-error
+    import importlib.util
     spec = importlib.util.spec_from_file_location(module_name, full_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/calculations/test_local_input.py
+++ b/tests/calculations/test_local_input.py
@@ -8,7 +8,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 """Tests for the `PwCalculation` class."""
-from __future__ import absolute_import, print_function
 
 import pytest
 
@@ -338,8 +337,8 @@ def test_diffusivity( #pylint: disable=too-many-locals
     file_regression
 ):
     """Test a `Wannier90Calculation` with various advanced combinations of the projections.
-    
-    For instance, using both diffusivity and radial_nodes, or diffusivity only, 
+
+    For instance, using both diffusivity and radial_nodes, or diffusivity only,
     and in combination with/without zaxis and xaxis."""
     from aiida_wannier90.orbitals import generate_projections
 
@@ -414,8 +413,8 @@ def test_spin_projections( #pylint: disable=too-many-locals
 ):
     """Test a `Wannier90Calculation` with various advanced combinations of the projections
     when using also spin.
-    
-    For instance, using both diffusivity and radial_nodes, or diffusivity only, 
+
+    For instance, using both diffusivity and radial_nodes, or diffusivity only,
     and in combination with/without zaxis and xaxis."""
     from aiida.orm import Dict
     from aiida_wannier90.orbitals import generate_projections

--- a/tests/calculations/test_remote_input.py
+++ b/tests/calculations/test_remote_input.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
 
 import os
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ import os
 import collections
 
 import pytest
-import six
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
 
@@ -144,7 +143,7 @@ def generate_calc_job_node(shared_datadir):
     def flatten_inputs(inputs, prefix=''):
         """Flatten inputs recursively like :meth:`aiida.engine.processes.process::Process._flatten_inputs`."""
         flat_inputs = []
-        for key, value in six.iteritems(inputs):
+        for key, value in inputs.iteritems():
             if isinstance(value, collections.Mapping):
                 flat_inputs.extend(
                     flatten_inputs(value, prefix=prefix + key + '__')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,13 +66,11 @@ def fixture_remotedata(fixture_localhost, shared_datadir):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         remote = RemoteData(remote_path=tmpdir, computer=fixture_localhost)
-        for file_path in os.listdir(dir_path):
-            abs_path = os.path.abspath(os.path.join(dir_path, file_path))
-            res_file_path = file_path
+        for file_path in dir_path.iterdir():
+            abs_path = str(file_path.resolve())
+            res_file_path = os.path.join(tmpdir, file_path.name)
             for old, new in replacement_mapping.items():
-                res_file_path = res_file_path.replace(
-                    old, new
-                )  # put using correct method
+                res_file_path = res_file_path.replace(old, new)
             shutil.copyfile(src=abs_path, dst=res_file_path)
         yield remote
 
@@ -273,6 +271,7 @@ def generate_win_params_gaas(generate_structure_gaas, generate_kpoints_mesh):
         from aiida import orm
         from aiida.tools import get_kpoints_path
         from aiida_wannier90.orbitals import generate_projections
+        projections_dict_mutable = {**projections_dict}
         structure = generate_structure_gaas()
         inputs = {
             'structure':
@@ -290,7 +289,9 @@ def generate_win_params_gaas(generate_structure_gaas, generate_kpoints_mesh):
                 }
             ),
             'projections':
-            generate_projections(projections_dict, structure=structure)
+            generate_projections(
+                projections_dict_mutable, structure=structure
+            )
         }
 
         return inputs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,7 @@ def fixture_remotedata(fixture_localhost, shared_datadir):
     dir_path = shared_datadir / 'gaas'
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        remote = RemoteData(
-            remote_path=tmpdir.name, computer=fixture_localhost
-        )
+        remote = RemoteData(remote_path=tmpdir, computer=fixture_localhost)
         for file_path in os.listdir(dir_path):
             abs_path = os.path.abspath(os.path.join(dir_path, file_path))
             res_file_path = file_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,7 @@ def generate_calc_job_node(shared_datadir):
     def flatten_inputs(inputs, prefix=''):
         """Flatten inputs recursively like :meth:`aiida.engine.processes.process::Process._flatten_inputs`."""
         flat_inputs = []
-        for key, value in inputs.iteritems():
+        for key, value in inputs.items():
             if isinstance(value, collections.Mapping):
                 flat_inputs.extend(
                     flatten_inputs(value, prefix=prefix + key + '__')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@
 ################################################################################
 # pylint: disable=redefined-outer-name
 """Initialise a text database and profile for pytest."""
-from __future__ import absolute_import
 
 import os
 import collections
@@ -55,7 +54,7 @@ def fixture_remotedata(fixture_localhost, shared_datadir):
     Return a `RemoteData` with contents from the specified directory. Optionally a
     mapping of strings to replace in the filenames can be passed. Note that the order
     of replacement is not guaranteed.
-    
+
     The RemoteData node is yielded and points to a folder in /tmp, and is removed at the end
     """
     from aiida.orm import RemoteData

--- a/tests/io/test_win_writer.py
+++ b/tests/io/test_win_writer.py
@@ -7,7 +7,6 @@
 # The code is hosted on GitHub at https://github.com/aiidateam/aiida-wannier90 #
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
-from __future__ import absolute_import
 
 
 def test_create_win_string(generate_win_params_gaas, file_regression):

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -8,7 +8,6 @@
 # For further information on the license, see the LICENSE.txt file             #
 ################################################################################
 
-from __future__ import absolute_import
 import pytest
 
 from aiida import orm


### PR DESCRIPTION
Fixes #93 

Removes the obvious ways in which python2 support was maintained, and explicitly changes the required / supported Python versions in the setup and on Travis.