### PR TITLE
Add missing outputs of MinimalW90WorkChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.1
+
+## Fixes and general improvements
+
+* Register pw2wannier90 `output_parameters` to the outputs of `MinimalW90WorkChain` [[#96]](https://github.com/aiidateam/aiida-wannier90/pull/96)
+
 # v2.0.0
 
 ## New features

--- a/aiida_wannier90/__init__.py
+++ b/aiida_wannier90/__init__.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import
 __authors__ = "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi, Junfeng Qiao, Norma Rivano, and the AiiDA team."
 __license__ = "MIT License, see LICENSE.txt file."
 ## If upgraded, remember to change it also in setup.json (for pip)
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 from . import io
 from . import parsers

--- a/aiida_wannier90/workflows/minimal.py
+++ b/aiida_wannier90/workflows/minimal.py
@@ -263,7 +263,6 @@ class MinimalW90WorkChain(WorkChain):
 
     def run_pw2wan(self):
         """Run pw2wannier90.x."""
-        self.out('nscf_output', self.ctx.pw_nscf.outputs.output_parameters)
         self.out('nnkp_file', self.ctx.w90_pp.outputs.nnkp_file)
 
         self.ctx.pw2wannier_parameters = {
@@ -305,6 +304,7 @@ class MinimalW90WorkChain(WorkChain):
         self.out(
             'pw2wan_remote_folder', self.ctx.pw2wannier.outputs.remote_folder
         )
+        self.out('p2wannier_output', self.ctx.pw2wannier.outputs.output_parameters)
 
         inputs = {
             'code': self.inputs.wannier_code,

--- a/aiida_wannier90/workflows/minimal.py
+++ b/aiida_wannier90/workflows/minimal.py
@@ -304,7 +304,9 @@ class MinimalW90WorkChain(WorkChain):
         self.out(
             'pw2wan_remote_folder', self.ctx.pw2wannier.outputs.remote_folder
         )
-        self.out('p2wannier_output', self.ctx.pw2wannier.outputs.output_parameters)
+        self.out(
+            'p2wannier_output', self.ctx.pw2wannier.outputs.output_parameters
+        )
 
         inputs = {
             'code': self.inputs.wannier_code,

--- a/setup.json
+++ b/setup.json
@@ -42,7 +42,7 @@
   ],
   "url": "https://github.com/aiidateam/aiida-wannier90",
   "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "classifiers": [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",


### PR DESCRIPTION
The required pw2wannier90 `output_parameters` of `MinimalW90WorkChain` is missing, which can result in the following error
```
Finished [11] The process did not register a required output.
```
Also remove the repeated line:
https://github.com/aiidateam/aiida-wannier90/blob/97cb70af588589d60166241c91432439211d430f/aiida_wannier90/workflows/minimal.py#L266
https://github.com/aiidateam/aiida-wannier90/blob/97cb70af588589d60166241c91432439211d430f/aiida_wannier90/workflows/minimal.py#L220