### PR TITLE
Set the `invalidates_cache` keyword for certain exit codes.

### DIFF
--- a/aiida_wannier90/calculations.py
+++ b/aiida_wannier90/calculations.py
@@ -161,13 +161,15 @@ class Wannier90Calculation(CalcJob):
         spec.exit_code(
             200,
             'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.'
+            message='The retrieved folder data node could not be accessed.',
+            invalidates_cache=True
         )
         spec.exit_code(
             210,
             'ERROR_OUTPUT_STDOUT_MISSING',
             message=
-            'The retrieved folder did not contain the required stdout output file.'
+            'The retrieved folder did not contain the required stdout output file.',
+            invalidates_cache=True
         )
         spec.exit_code(
             300,

--- a/setup.json
+++ b/setup.json
@@ -37,7 +37,7 @@
   "author": "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi, Junfeng Qiao, Norma Rivano, and the AiiDA team",
   "author_email": "",
   "install_requires": [
-    "aiida-core>=1.0.0,<2"
+    "aiida-core>=1.1.0,<2"
   ],
   "url": "https://github.com/aiidateam/aiida-wannier90",
   "python_requires": ">=3.6",


### PR DESCRIPTION
Fixes #102.

For exit codes where no or incomplete output was retrieved, the `invalidates_cache` keyword is set to True. Since these are exit codes that are often caused by intermittent issues (out of memory, node failure, ...), they should not be used as cache source.

Because the `invalidates_cache` keyword was introduced in AiiDA version 1.1, support for the 1.0 version is dropped.