### PR TITLE
Make tests compatible with aiida-core v1.4+

### DIFF
--- a/examples/example01/create_local_input_folder.py
+++ b/examples/example01/create_local_input_folder.py
@@ -28,7 +28,7 @@ def get_unstored_folder_data(seedname='aiida'):
         ('gaas.mmn', '{}.mmn'.format(seedname))
     ]:
         folder_node.put_object_from_file(
-            path=os.path.join(files_folder, local_file_name),
+            os.path.join(files_folder, local_file_name),
             key=file_name_in_aiida,
             encoding=None
         )


### PR DESCRIPTION
Use `put_object_from_file` with positional instead of keyword arguments for cross-compatibility with different AiiDA versions.