### PR TITLE
Edit the retrieve_list to include more werr files

### DIFF
--- a/src/aiida_wannier90/calculations/postw90.py
+++ b/src/aiida_wannier90/calculations/postw90.py
@@ -78,7 +78,7 @@ class Postw90Calculation(CalcJob):
         ".vdw",
         "_band_proj.dat",
         "_band.labelinfo.dat",
-        ".node_00001.werr",
+        ".node_*.werr",
     )
 
     _DEFAULT_RETRIEVE_TEMPORARY_SUFFIXES = (

--- a/src/aiida_wannier90/calculations/wannier90.py
+++ b/src/aiida_wannier90/calculations/wannier90.py
@@ -122,7 +122,7 @@ class Wannier90Calculation(CalcJob):
         ".vdw",
         "_band_proj.dat",
         "_band.labelinfo.dat",
-        ".node_00001.werr",
+        ".node_*.werr",
     )
 
     @classmethod

--- a/src/aiida_wannier90/parsers/postw90.py
+++ b/src/aiida_wannier90/parsers/postw90.py
@@ -120,7 +120,8 @@ class Postw90Parser(Parser):
             )
             return self.exit_codes.ERROR_WERR_FILE_PRESENT
 
-        # Some times the error files are aiida.node_00001.werr, ...
+        # Some times the error files are aiida.node_XXXXX.werr, ...
+        # The XXXXX are 5-digit index of processor
         error_file_name = re.compile(seedname + r".+?\.werr")
         for filename in out_folder.base.repository.list_object_names():
             if error_file_name.match(filename):

--- a/src/aiida_wannier90/parsers/wannier90.py
+++ b/src/aiida_wannier90/parsers/wannier90.py
@@ -126,7 +126,8 @@ class Wannier90Parser(Parser):
             )
             return self.exit_codes.ERROR_WERR_FILE_PRESENT
 
-        # Some times the error files are aiida.node_00001.werr, ...
+        # Some times the error files are aiida.node_XXXXX.werr, ...
+        # The XXXXX are 5-digit index of processor
         error_file_name = re.compile(seedname + r".+?\.werr")
         for filename in out_folder.base.repository.list_object_names():
             if error_file_name.match(filename):

--- a/tests/calculations/test_local_input.py
+++ b/tests/calculations/test_local_input.py
@@ -105,7 +105,7 @@ def test_default(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []
@@ -191,7 +191,7 @@ def test_default_plot(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []
@@ -304,7 +304,7 @@ def test_no_projections(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []
@@ -369,7 +369,7 @@ def test_list_projections(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []

--- a/tests/calculations/test_remote_input.py
+++ b/tests/calculations/test_remote_input.py
@@ -104,7 +104,7 @@ def test_default_remote(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []
@@ -201,7 +201,7 @@ def test_unk_symlink(
             ".vdw",
             "_band_proj.dat",
             "_band.labelinfo.dat",
-            ".node_00001.werr",
+            ".node_*.werr",
         )
     ]
     retrieve_temporary_list = []


### PR DESCRIPTION
When wannier90/postw90 calculation fails on specific processor, the error file will be named as `aiida.node_xxxxx.werr`. 
The 'xxxxx' is a 5-digit index of processor. These werr files should also be retrieved.